### PR TITLE
Replace CHANGELOG versioning with label versioning

### DIFF
--- a/bin/merge
+++ b/bin/merge
@@ -51,21 +51,21 @@ if [[ "$merged" == "false" ]]; then
 
     old_version=($(sed 's/.*"\(.*\)"/\1/' version.sbt | tr "." "\n"))
 
-    if [[ $(echo ${labels[@]}) == *"breaking"* ]]; then
+    if [[ $(echo ${labels[@]}) == *"version: breaking"* ]]; then
         if [[ "${old_version[0]}" == "0" ]]; then
             new_version="0.$((old_version[1] + 1)).0"
         else
             new_version="$((old_version[0] + 1)).0.0"
         fi
-    elif [[ $(echo ${labels[@]}) == *"feature"* ]]; then
+    elif [[ $(echo ${labels[@]}) == *"version: feature"* ]]; then
         if [[ "${old_version[0]}" == "0" ]]; then
             new_version="0.${old_version[1]}.$((old_version[2] + 1))"
         else
             new_version="${old_version[0]}.$((old_version[1] + 1)).0"
         fi
-    elif [[ $(echo ${labels[@]}) == *"revision"* ]]; then
+    elif [[ $(echo ${labels[@]}) == *"version: revision"* ]]; then
         new_version="${old_version[0]}.${old_version[1]}.$((old_version[2] + 1))"
-    elif [[ $(echo ${labels[@]}) == *"release"* ]]; then
+    elif [[ $(echo ${labels[@]}) == *"version: release"* ]]; then
       if [[ "${old_version[0]}" == "0" ]]; then
           new_version="1.0.0"
       else

--- a/bin/merge
+++ b/bin/merge
@@ -29,17 +29,14 @@ if [[ -z "$repo" || -z "$pull_request" ]]; then
 fi
 
 pr_url="https://api.github.com/repos/${repo}/pulls/${pull_request}"
+labels_url="https://api.github.com/repos/${repo}/issues/${pull_request}/labels"
 directory=$(mktemp -d "/tmp/slamdata-merge.XXXXXXXX")
-
-breaking="CHANGELOG/breaking.md"
-feature="CHANGELOG/feature.md"
-revision="CHANGELOG/revision.md"
-release="CHANGELOG/release.md"
 
 # FIXME: removed -e around this command, don’t know why I had to
 set +e
-read -d '' merged base_clone pr_clone submitter base_sha base_ref pr_ref \
-     < <(curl -f -s $pr_url | json merged base.repo.ssh_url head.repo.ssh_url user.login base.sha base.ref head.ref)
+read -d '' merged title changelog base_clone pr_clone submitter base_sha base_ref pr_ref \
+     < <(curl -f -s $pr_url | json merged title body base.repo.ssh_url head.repo.ssh_url user.login base.sha base.ref head.ref)
+labels=$(curl -f -s $labels_url | json -a name)
 set -e
 
 if [[ "$merged" == "false" ]]; then
@@ -54,38 +51,35 @@ if [[ "$merged" == "false" ]]; then
 
     old_version=($(sed 's/.*"\(.*\)"/\1/' version.sbt | tr "." "\n"))
 
-    if [[ -e "$breaking" ]]; then
+    if [[ $(echo ${labels[@]}) == *"breaking"* ]]; then
         if [[ "${old_version[0]}" == "0" ]]; then
             new_version="0.$((old_version[1] + 1)).0"
         else
             new_version="$((old_version[0] + 1)).0.0"
         fi
-        git mv "$breaking" CHANGELOG/${new_version}.md
-    elif [[ -e "$feature" ]]; then
+    elif [[ $(echo ${labels[@]}) == *"feature"* ]]; then
         if [[ "${old_version[0]}" == "0" ]]; then
             new_version="0.${old_version[1]}.$((old_version[2] + 1))"
         else
             new_version="${old_version[0]}.$((old_version[1] + 1)).0"
         fi
-        git mv "$feature" CHANGELOG/${new_version}.md
-    elif [[ -e "$revision" ]]; then
+    elif [[ $(echo ${labels[@]}) == *"revision"* ]]; then
         new_version="${old_version[0]}.${old_version[1]}.$((old_version[2] + 1))"
-        git mv "$revision" CHANGELOG/${new_version}.md
-    elif [[ -e "$release" ]]; then
+    elif [[ $(echo ${labels[@]}) == *"release"* ]]; then
       if [[ "${old_version[0]}" == "0" ]]; then
-          git mv "$release" CHANGELOG/1.0.0.md
+          new_version="1.0.0"
       else
           echo "error: Current version (${old_version[0]}.${old_version[1]}.${old_version[2]}) must be < 1.0.0 to release."
           exit 1
       fi
     else
-        echo "error: Missing a semantic CHANGELOG file."
+        echo "error: Missing a semantic version label on the PR."
         exit 1
     fi
 
     echo "version in ThisBuild := \"${new_version}\"" > version.sbt
 
-    git commit -a --amend --no-edit # amend the merge commit
+    git commit -a --amend -m "$new_version: $title" -m "(Merge branch '$tmp_branch')" -m "$changelog"
     git push origin $base_ref
     rm -rf $directory
 


### PR DESCRIPTION
Instead of creating a CHANGELOG/{increment-type}.md file, we now use the
PR description as the changelog, and a GitHub label as the increment type.