### PR TITLE
support package.json, private repos, rewrite to python

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Development tools for SlamData
 
 ## Merge Instructions
-How to get up and running with `merge`.
+How to get up and running with `sdmerge`.
 
 1. Git clone the slamdata/devtools repo using: 
 
@@ -10,19 +10,22 @@ How to get up and running with `merge`.
 → git clone https://github.com/slamdata/devtools.git
 ```
 
-2. The `merge` script depends on [json](http://trentm.com/json/). You can install it using `sudo npm install -g json`.
-NPM depends on [Node.js](https://nodejs.org).
+2. The `sdmerge` script depends on python 2.7.
 
 3. You also need to exchange ssh keys with github. This requires two steps:
   * Generate ssh [keys](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)
   * Exchage public key with [github](https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/)
 
-4. In addition ensure the PR has a version label assigned to it.
+4. To merge a PR from private repository, you need to get github access token from [here](https://github.com/settings/tokens). Provide it to the script through GITHUB_TOKEN env variable.
 
-5. Now run the `merge` script as follows:
+5. In addition ensure the PR has a version label assigned to it.
+
+6. Now run the `sdmerge` script as follows:
 
 ```
-→ merge REPO-NAME PR-NUMBER
+→ sdmerge REPO-NAME PR-NUMBER
 ```
 
-replacing `REPO-NAME` by the name of a repository, for exapmle `quasar-analytics/quasar`.
+replacing `REPO-NAME` by the name of a repository, for exapmle `quasar-analytics/quasar`. 
+
+`REPO-NAME` may be skipped if script is run from target repo directory and has remote named `upstream`.

--- a/bin/sdmerge
+++ b/bin/sdmerge
@@ -1,14 +1,20 @@
-#!/usr/bin/env bash
+#!/usr/bin/env python
+import sys
+import subprocess
+import re
+import tempfile
+import httplib
+import json
+import os
+import shutil
 
-set -euo pipefail # STRICT MODE
-IFS=$'\n\t'       # http://redsymbol.net/articles/unofficial-bash-strict-mode/
-
-# Takes one or two arguments – an optional GitHub repository name and a PR number.
+# Takes one or two arguments - an optional GitHub repository name and a PR number.
 # If the repository name is unspecified, it will be inferred (if possible) from
 # the `upstream` remote of the git repository in the current working directory.
+# To access PR in private repository it needs GITHUB_TOKEN env variable set.
 #
 # This script ensures the PR is unmerged and has a one of the
-# “version:” GitHub labels applied to it (the name is used to determine which
+# "version:" GitHub labels applied to it (the name is used to determine which
 # version component to increment).
 #
 # Pre-1.0 projects are supported (i.e. those with a version of 0.x.y) and
@@ -16,133 +22,207 @@ IFS=$'\n\t'       # http://redsymbol.net/articles/unofficial-bash-strict-mode/
 # other change will increment the patch version.
 #
 # When the pre-1.0 API has reached stability and is ready to release, use the
-# “version: release” label, which will transition the version to 1.0.0.
+# "version: release" label, which will transition the version to 1.0.0.
 #
 # It increments the version, copies the PR title and description to the merge
 # commit, and merges into master.
-#
-# Depends on: curl, json (http://trentm.com/json/#INSTALL-PROJECT-BUGS)
 
-UPSTREAM=upstream   # the default upstream remote name (used if only one argument is specified)
-DEPTH=100           # number of commits to fetch from upstream
+UPSTREAM = 'upstream'  # the default upstream remote name (used if only one argument is specified)
+DEPTH = 100            # number of commits to fetch from upstream
 
-mainwork() {
-  if [[ $# -eq 2 ]]; then
-    repo=${1:-}
-    pull_request=${2:-}
-  else
-    pull_request=${1:-}
 
-    set +e
-    repo="$(git remote -v | grep $UPSTREAM | grep fetch | cut -f2 | cut -d ' ' -f1 | sed 's/git@github.com://' | sed 's|https://github.com/||' | sed 's/.git//')"
-    set -e
+def help():
+    print """usage: {0} [-h] [REPO-NAME] PR-NUMBER
 
-    if [[ "$repo" == "" ]]; then
-      echo "error: unable to determine current working repository (do you have a remote named '$UPSTREAM'?)"
-      echo 'error: please specify both arguments, rather than just the PR number'
-      exit 1
-    fi
-  fi
-
-  pr_url="https://api.github.com/repos/${repo}/pulls/${pull_request}"
-  labels_url="https://api.github.com/repos/${repo}/issues/${pull_request}/labels"
-  directory=$(mktemp -d "/tmp/slamdata-merge.XXXXXXXX")
-
-  # FIXME: removed -e around this command, don’t know why I had to
-  set +e
-  read -d '' merged title base_clone pr_clone submitter base_sha base_ref pr_ref changelog \
-    < <(curl -f -s $pr_url | json merged title base.repo.ssh_url head.repo.ssh_url user.login base.sha base.ref head.ref body -e 'this.body = this.body.replace(/\r\n/g, "{{[[ENDL]]}}")')
-
-  labels=$(curl -f -s $labels_url | json -a name)
-
-  set -e
-
-  changelog=${changelog//'{{[[ENDL]]}}'/$'\n'}
-
-  if [[ "$merged" == "false" ]]; then
-    tmp_branch=${submitter}-${pr_ref}
-
-    git clone --depth $DEPTH $base_clone $directory
-
-    cd $directory
-    git fetch origin pull/$pull_request/head:$tmp_branch
-    git checkout $base_ref
-    git merge --no-ff --no-edit $tmp_branch
-
-    old_version=($(sed 's/.*"\(.*\)"/\1/' version.sbt | tr "." "\n"))
-
-    if [[ $(echo ${labels[@]}) == *"version: breaking"* ]]; then
-      if [[ "${old_version[0]}" == "0" ]]; then
-        new_version="0.$((old_version[1] + 1)).0"
-      else
-        new_version="$((old_version[0] + 1)).0.0"
-      fi
-    elif [[ $(echo ${labels[@]}) == *"version: feature"* ]]; then
-      if [[ "${old_version[0]}" == "0" ]]; then
-        new_version="0.${old_version[1]}.$((old_version[2] + 1))"
-      else
-        new_version="${old_version[0]}.$((old_version[1] + 1)).0"
-      fi
-    elif [[ $(echo ${labels[@]}) == *"version: revision"* ]]; then
-      new_version="${old_version[0]}.${old_version[1]}.$((old_version[2] + 1))"
-    elif [[ $(echo ${labels[@]}) == *"version: release"* ]]; then
-      if [[ "${old_version[0]}" == "0" ]]; then
-        new_version="1.0.0"
-      else
-        echo "error: Current version (${old_version[0]}.${old_version[1]}.${old_version[2]}) must be < 1.0.0 to release."
-        exit 1
-      fi
-    else
-      echo "error: Missing a semantic version label on the PR."
-      exit 1
-    fi
-
-    echo "version in ThisBuild := \"${new_version}\"" > version.sbt
-
-    git commit -a --amend -m "$new_version: $title" -m "(Merge branch '$tmp_branch')" -m "$changelog"
-    git push origin $base_ref
-
-    cd /tmp
-    rm -rf $directory
-
-    echo "success: ${repo}#${pull_request} has version ${new_version} in ${base_ref}"
-    exit 0
-  else
-    echo "error: ${repo}#${pull_request} has already been merged"
-    exit 1
-  fi
-}
-
-usage() {
-  cat << EOF
-usage: $0 [-h] [REPO-NAME] PR-NUMBER
-
-Merge a cloned repo to REPO-NAME with PR-NUMBER. Merge depends on json located
-here: http://trentm.com/json/ which can be installed using: sudo npm install -g json.
-Github keys should be exchanged before using $0. Instructions can be found here:
-https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account.
+Merge a cloned repo to REPO-NAME with PR-NUMBER. Github keys should be exchanged before using {0}. 
+Instructions can be found here: https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account.
+To fetch metadata of private repositories provide github api token through GITHUB_TOKEN env variable.
 Lastly, ensure PR has a version label assigned to it.
 
 -h            help (also trigged with no parameters): display this help and exit
 <REPO-NAME>   the repo name, for example: quasar-analytics/quasar
 <PR-NUMBER>   the pull request number: 2030
 
-Example: sdmerge quasar-analytics/quasar 2030
+Example: sdmerge quasar-analytics/quasar 2030""".format(sys.argv[0])
+    exit(1)
 
-EOF
-}
 
-# if no args are passed in print usage
-[ $# -eq 0 ] && usage
+def infer_repo_slug():
+    out = subprocess.check_output(["git", "remote", "-v"])
+    upstream_fetch_regex = "^" + re.escape(UPSTREAM) + r"\t(?:git@github\.com:|https://github\.com/)(.+?)(?:.git)? \(fetch\)$"
+    match = re.compile(upstream_fetch_regex, re.MULTILINE).search(out)
+    if match is None:
+        print "error: unable to determine current working repository (do you have a remote named '%s'?)" % UPSTREAM
+        exit(1)
+    else:
+        return match.group(1)
 
-# command line parsing logic
-while getopts ":h" opt; do
-  case $opt in
-    h | *)
-      usage
-      exit 1
-      ;;
-  esac
-done
 
-mainwork $*
+def call_github_api(url, token):
+    conn = httplib.HTTPSConnection("api.github.com")
+
+    headers = {"User-Agent": "sdmerge"}  # user agent is required by github api
+    if token is not None:
+        headers.update({"Authorization": "token " + token})
+
+    conn.request("GET", url, headers=headers)
+    response = conn.getresponse()
+    if response.status != 200:
+        if response.status == 403 and token is None:
+            print "error: set GITHUB_TOKEN env variable to access private repositories"
+        elif response.status == 404:
+            print "error: pull request with this number does not exist"
+            if token is None:
+                print "error: if you are trying to access private repository make sure that GITHUB_TOKEN is set"
+        else:
+            print "error: invalid response: ", response.status, response.reason
+            print response.read()
+        conn.close()
+        exit(1)
+    else:
+        raw_data = response.read()
+        conn.close()
+        return json.loads(raw_data)
+
+
+def get_pr_metadata():
+    github_token = os.environ.get("GITHUB_TOKEN")
+    endpoint = "/repos/%s/pulls/%s" % (repo_slug, pull_request_number)
+    return call_github_api(endpoint, github_token)
+
+
+def read_sbt_version():
+    with open("version.sbt") as file:
+        return re.match(r"version in ThisBuild := \"(.+)\"", file.read()).group(1)
+
+
+def read_npm_version():
+    with open("package.json") as file:
+        return json.load(file)["version"].replace("v", "")
+
+
+def save_sbt_version(version):
+    with open("version.sbt", "w") as file:
+        file.write("version in ThisBuild := \"%s\"" % version)
+
+
+def save_npm_version(version):
+    with open("package.json") as file:
+        content = file.read()
+
+    # sadly parsing file as json, replacing the value and saving it back reorders everything, doing a big mess
+    new_content = re.sub("(?<=\"version\": \").+?(?=\")", "v" + version, content)
+
+    with open("package.json", "w") as file:
+        file.write(new_content)
+
+
+def resolve_version_file_type():
+    if os.path.exists("version.sbt"):
+        return read_sbt_version, save_sbt_version
+    elif os.path.exists("package.json"):
+        return read_npm_version, save_npm_version
+    else:
+        print "error: unable to determine project version file. Expected to find one of those: version.sbt, package.json"
+        exit(1)
+
+
+def bump_version_file():
+    major = 0
+    minor = 1
+    patch = 2
+
+    def bump(version, component):
+        version[component] += 1
+        for i in range(component + 1, len(version)):
+            version[i] = 0
+
+    def is_unreleased(v):
+        return v[major] == 0
+
+    def parse_version(s):
+        return map(int, s.split("."))
+
+    def stringify_version(v):
+        return ".".join(map(str, v))
+
+    read_version, save_version = resolve_version_file_type()
+
+    version = parse_version(read_version())
+    if "version: breaking" in pr_labels:
+        if is_unreleased(version):
+            bump(version, minor)
+        else:
+            bump(version, major)
+    elif "version: feature" in pr_labels:
+        if is_unreleased(version):
+            bump(version, patch)
+        else:
+            bump(version, minor)
+    elif "version: revision" in pr_labels:
+        bump(version, patch)
+    elif "version: release" in pr_labels:
+        if is_unreleased(version):
+            version = [1, 0, 0]
+        else:
+            print "error: current version (%s) must be < 1.0.0 to release" % stringify_version(version)
+            exit(1)
+    else:
+        print "error: Missing a semantic version label on the PR."
+        exit(1)
+    new_version_str = stringify_version(version)
+    save_version(new_version_str)
+    return new_version_str
+
+
+if len(sys.argv) == 3:
+    repo_slug = sys.argv[1]
+    pull_request_number = sys.argv[2]
+elif len(sys.argv) == 2:
+    repo_slug = infer_repo_slug()
+    pull_request_number = sys.argv[1]
+else:
+    help()
+
+
+pr_data = get_pr_metadata()
+pr_submitter = pr_data["user"]["login"]
+pr_branch = pr_data["head"]["ref"]
+pr_base_branch = pr_data["base"]["ref"]
+pr_base_repo = pr_data["base"]["repo"]["ssh_url"]
+pr_title = pr_data["title"]
+pr_labels = map(lambda x: x["name"], pr_data["labels"])
+pr_changelog = pr_data["body"].replace("\r\n", "\n")
+pr_is_merged = pr_data["merged"]
+
+if pr_is_merged:
+    print "error: %s#%s has already been merged" % (repo_slug, pull_request_number)
+    exit(1)
+
+
+clone_directory = tempfile.mkdtemp(prefix="/tmp/slamdata-merge.")
+
+try:
+    # merge PR
+    temporary_branch = pr_submitter + "-" + pr_branch
+    subprocess.check_call(["git", "clone", "--depth", str(DEPTH), pr_base_repo, clone_directory])
+    os.chdir(clone_directory)
+    subprocess.check_call(["git", "fetch", "origin", "pull/%s/head:%s" % (pull_request_number, temporary_branch)])
+    subprocess.check_call(["git", "checkout", pr_base_branch])
+    subprocess.check_call(["git", "merge", "--no-ff", "--no-edit", temporary_branch])
+
+    # add version bump to the commit
+    new_version = bump_version_file()
+    subprocess.check_call([
+        "git", "commit", "-a", "--amend",
+        "-m", "%s: %s" % (new_version, pr_title),
+        "-m", "(Merge branch '%s')" % temporary_branch,
+        "-m", pr_changelog
+    ])
+
+    # push changes
+    subprocess.check_call(["git", "push", "origin", pr_base_branch])
+finally:
+    shutil.rmtree(clone_directory)
+
+print "success: %s#%s has version %s in %s" % (repo_slug, pull_request_number, new_version, pr_base_branch)


### PR DESCRIPTION
# package.json
sdmerge now looks for current version in package.json file if version.sbt does not exist.

# private repos
it is possible to merge PRs in private repos. Fetching, merging and pushing was possible before, as it only requires ssh keys exchanged. The only thing that needs extra access is github api to fetch PR metadata like labels. This requires providing github api token and is done through env variable GITHUB_TOKEN. It is still possible to use the script with public repos if the variable is not set.

# python
To aviod dependencies on json, curl, node and bash, script was rewritten in python 2.7 using only the standard library. This should hopefully make life easier also on windows.

Apart from things listed above, the behavior didn't change.