### PR TITLE
Explicitly require python 2 in shebang line

### DIFF
--- a/bin/sdmerge
+++ b/bin/sdmerge
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys
 import subprocess
 import re


### PR DESCRIPTION
According to [those recommendations](https://www.python.org/dev/peps/pep-0394/#recommendation), executable named python2 should always exist because python can point to python 2 or python 3.
So with this change it should be possible to run ./sdmerge even if on given machine the default python version is 3.